### PR TITLE
Add Discord File Upload to SCSTCollectData.ps1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+SCSTInfo.log

--- a/New-ScstLog.ps1
+++ b/New-ScstLog.ps1
@@ -1,0 +1,18 @@
+function New-ScstLog($scstlog){
+
+    # common args
+    $outfile = @{FilePath=$scstlog;Encoding="utf8";Append=$true}
+
+    # generate file
+    $ProgressPreference = "SilentlyContinue" #hide progress bars
+    Get-ComputerInfo | Select-Object WindowsProductName, WindowsVersion, OsHardwareAbstractionLayer | Out-File -FilePath "$scstlog" -Encoding utf8 -Force
+    Get-CimInstance -ClassName CIM_Processor | Select-Object -Property Name, MaxClockSpeed, SocketDesignation, Manufacturer | Out-File @outfile
+    Get-CimInstance -ClassName CIM_VideoController | Format-Table -AutoSize -Property Name, CurrentHorizontalResolution, CurrentVerticalResolution, CurrentRefreshRate, @{Name="AdapterRamGB"; Expression={[int]($_.AdapterRam/1GB)}}, DriverDate, DriverVersion | Out-File @outfile
+    Get-CimInstance -ClassName CIM_PhysicalMemory | Format-Table -AutoSize Manufacturer, PartNumber, Speed, DeviceLocator, @{Name="CapacityGB"; Expression={[int]($_.Capacity/1GB)}} | Out-File @outfile
+    Get-CimInstance -ClassName CIM_DiskDrive | Format-Table -AutoSize DeviceID, Model, @{Name="SizeGB"; Expression={[int]($_.Size/1GB)}} | Out-File @outfile
+    Get-CimInstance -ClassName CIM_LogicalDisk | Format-Table -AutoSize DeviceID, @{Name="SizeGB"; Expression={[int]($_.Size/1GB)}} | Out-File @outfile
+
+    # return file exists bool
+    Test-Path $scstlog
+    
+}

--- a/SCSTCOLLECTDATA.ps1
+++ b/SCSTCOLLECTDATA.ps1
@@ -1,23 +1,6 @@
 # Run a Powershell script that isnt signed ONCE and ONLY DURING THIS SESSION
 Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
 
-###
-#BEGIN SELF ELEVATE TO ADMIN
-###
-
-# Self-elevate the script if not already running as administrator
-if (-Not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] 'Administrator')) {
- if ([int](Get-CimInstance -Class Win32_OperatingSystem | Select-Object -ExpandProperty BuildNumber) -ge 6000) {
-  $CommandLine = "-File `"" + $MyInvocation.MyCommand.Path + "`" " + $MyInvocation.UnboundArguments
-  Start-Process -FilePath PowerShell.exe -Verb Runas -ArgumentList $CommandLine
-  Exit
- }
-}
-
-###
-#END SELF ELEVATE TO ADMIN
-###
-
 # Set location to script path
 Set-Location (Split-Path -Parent $MyInvocation.MyCommand.Path)
 
@@ -67,3 +50,5 @@ Get-CimInstance -ClassName CIM_LogicalDisk | Format-Table -AutoSize DeviceID, @{
 ##
 #END HOUSEKEEPING
 ##
+
+$host.UI.RawUI.ReadKey();

--- a/SCSTCOLLECTDATA.ps1
+++ b/SCSTCOLLECTDATA.ps1
@@ -1,5 +1,8 @@
 Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
 
+#set location to script path
+Set-Location (Split-Path -Parent $MyInvocation.MyCommand.Path)
+
 ###
 #BEGIN SELF ELEVATE TO ADMIN
 ###

--- a/SCSTCOLLECTDATA.ps1
+++ b/SCSTCOLLECTDATA.ps1
@@ -4,51 +4,19 @@ Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
 # Set location to script path
 Set-Location (Split-Path -Parent $MyInvocation.MyCommand.Path)
 
-##
-#BEGIN VARIABLES
-##
-
+# Settings
 $PSTitle = "Scavengers Community Support Tool Data Only"
-$host.UI.RawUI.WindowTitle = $PSTitle
 $scstlog = "SCSTInfo.log"
+$outfile = @{FilePath=$scstlog;Encoding="utf8";Append=$true}
 
-##
-#END VARIABLES
-##
+# Set Window Title
+$host.UI.RawUI.WindowTitle = $PSTitle
 
-##
-#BEGIN LOGGING This section gathers information about the computer specs and creates and appends the data to the SST logfile.
-##
-
+# Log Data
+$ProgressPreference = "SilentlyContinue" #hide progress bars
 Get-ComputerInfo | Select-Object WindowsProductName, WindowsVersion, OsHardwareAbstractionLayer | Out-File -FilePath "$scstlog" -Encoding utf8 -Force
-Get-CimInstance -ClassName CIM_Processor | Select-Object -Property Name, MaxClockSpeed, SocketDesignation, Manufacturer | Out-File -FilePath "$scstlog" -Encoding utf8 -Append
-Get-CimInstance -ClassName CIM_VideoController | Format-Table -AutoSize -Property Name, CurrentHorizontalResolution, CurrentVerticalResolution, CurrentRefreshRate, @{Name="AdapterRamGB"; Expression={[int]($_.AdapterRam/1GB)}}, DriverDate, DriverVersion | Out-File -FilePath "$scstlog" -Encoding utf8 -Append
-Get-CimInstance -ClassName CIM_PhysicalMemory | Format-Table -AutoSize Manufacturer, PartNumber, Speed, DeviceLocator, @{Name="CapacityGB"; Expression={[int]($_.Capacity/1GB)}} | Out-File -FilePath "$scstlog" -Encoding utf8 -Append
-Get-CimInstance -ClassName CIM_DiskDrive | Format-Table -AutoSize DeviceID, Model, @{Name="SizeGB"; Expression={[int]($_.Size/1GB)}} | Out-File -FilePath "$scstlog" -Encoding utf8 -Append
-Get-CimInstance -ClassName CIM_LogicalDisk | Format-Table -AutoSize DeviceID, @{Name="SizeGB"; Expression={[int]($_.Size/1GB)}} | Out-File -FilePath "$scstlog" -Encoding utf8 -Append
-
-##
-#END LOGGING
-##
-
-##
-#BEGIN LOG TRANSMITTAL Here we are automatically posting the SST.log file to the discord for dev tracking and troubleshooting.
-##
-
-
-
-##
-#END LOG TRANSMITTAL
-##
-
-##
-#BEGIN HOUSEKEEPING Here we are removing all of the files and folders we created during the process so we arent leaving things behind.
-##
-
-#Remove-Item -Path "$env:TEMP\SCST.log"
-
-##
-#END HOUSEKEEPING
-##
-
-$host.UI.RawUI.ReadKey();
+Get-CimInstance -ClassName CIM_Processor | Select-Object -Property Name, MaxClockSpeed, SocketDesignation, Manufacturer | Out-File @outfile
+Get-CimInstance -ClassName CIM_VideoController | Format-Table -AutoSize -Property Name, CurrentHorizontalResolution, CurrentVerticalResolution, CurrentRefreshRate, @{Name="AdapterRamGB"; Expression={[int]($_.AdapterRam/1GB)}}, DriverDate, DriverVersion | Out-File @outfile
+Get-CimInstance -ClassName CIM_PhysicalMemory | Format-Table -AutoSize Manufacturer, PartNumber, Speed, DeviceLocator, @{Name="CapacityGB"; Expression={[int]($_.Capacity/1GB)}} | Out-File @outfile
+Get-CimInstance -ClassName CIM_DiskDrive | Format-Table -AutoSize DeviceID, Model, @{Name="SizeGB"; Expression={[int]($_.Size/1GB)}} | Out-File @outfile
+Get-CimInstance -ClassName CIM_LogicalDisk | Format-Table -AutoSize DeviceID, @{Name="SizeGB"; Expression={[int]($_.Size/1GB)}} | Out-File @outfile

--- a/SCSTCOLLECTDATA.ps1
+++ b/SCSTCOLLECTDATA.ps1
@@ -4,19 +4,15 @@ Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
 # Set location to script path
 Set-Location (Split-Path -Parent $MyInvocation.MyCommand.Path)
 
+# Includes
+. .\New-ScstLog.ps1
+
 # Settings
 $PSTitle = "Scavengers Community Support Tool Data Only"
 $scstlog = "SCSTInfo.log"
-$outfile = @{FilePath=$scstlog;Encoding="utf8";Append=$true}
 
 # Set Window Title
 $host.UI.RawUI.WindowTitle = $PSTitle
 
-# Log Data
-$ProgressPreference = "SilentlyContinue" #hide progress bars
-Get-ComputerInfo | Select-Object WindowsProductName, WindowsVersion, OsHardwareAbstractionLayer | Out-File -FilePath "$scstlog" -Encoding utf8 -Force
-Get-CimInstance -ClassName CIM_Processor | Select-Object -Property Name, MaxClockSpeed, SocketDesignation, Manufacturer | Out-File @outfile
-Get-CimInstance -ClassName CIM_VideoController | Format-Table -AutoSize -Property Name, CurrentHorizontalResolution, CurrentVerticalResolution, CurrentRefreshRate, @{Name="AdapterRamGB"; Expression={[int]($_.AdapterRam/1GB)}}, DriverDate, DriverVersion | Out-File @outfile
-Get-CimInstance -ClassName CIM_PhysicalMemory | Format-Table -AutoSize Manufacturer, PartNumber, Speed, DeviceLocator, @{Name="CapacityGB"; Expression={[int]($_.Capacity/1GB)}} | Out-File @outfile
-Get-CimInstance -ClassName CIM_DiskDrive | Format-Table -AutoSize DeviceID, Model, @{Name="SizeGB"; Expression={[int]($_.Size/1GB)}} | Out-File @outfile
-Get-CimInstance -ClassName CIM_LogicalDisk | Format-Table -AutoSize DeviceID, @{Name="SizeGB"; Expression={[int]($_.Size/1GB)}} | Out-File @outfile
+# Generate Log
+New-ScstLog $scstlog

--- a/SCSTCOLLECTDATA.ps1
+++ b/SCSTCOLLECTDATA.ps1
@@ -30,15 +30,7 @@ $PSTitle = "Scavengers Community Support Tool Data Only"
 
 $host.UI.RawUI.WindowTitle = $PSTitle
 
-$userdownloads = "$env:USERPROFILE\Downloads"
-
-if (Test-Path $scstlog) {
-  }
-  else {
-    New-Item "$userdownloads\SCSTInfo.log"
-  }
-
-$scstlog = "$userdownloads\SCSTInfo.log"
+$scstlog = "$env:USERPROFILE\Downloads\SCSTInfo.log"
 
 ##
 #END VARIABLES

--- a/SCSTCOLLECTDATA.ps1
+++ b/SCSTCOLLECTDATA.ps1
@@ -33,7 +33,7 @@ $PSTitle = "Scavengers Community Support Tool Data Only"
 
 $host.UI.RawUI.WindowTitle = $PSTitle
 
-$scstlog = "$env:USERPROFILE\Downloads\SCSTInfo.log"
+$scstlog = "SCSTInfo.log"
 
 ##
 #END VARIABLES

--- a/SCSTCOLLECTDATA.ps1
+++ b/SCSTCOLLECTDATA.ps1
@@ -6,13 +6,17 @@ Set-Location (Split-Path -Parent $MyInvocation.MyCommand.Path)
 
 # Includes
 . .\New-ScstLog.ps1
+. .\Submit-TextFile.ps1
 
 # Settings
-$PSTitle = "Scavengers Community Support Tool Data Only"
-$scstlog = "SCSTInfo.log"
+$pst = "Scavengers Community Support Tool Data Only"
+$log = "SCSTInfo.log"
+$uri = 'https://discord.com/api/webhooks/838597970369708123/f95KX4IkB4qbt10eMdiW9SMyBEf_5uMPsr2vwXtoxNmE6OG4B0fFGM_KUesDb8wOTEJQ'
 
 # Set Window Title
-$host.UI.RawUI.WindowTitle = $PSTitle
+$host.UI.RawUI.WindowTitle = $pst
 
-# Generate Log
-New-ScstLog $scstlog
+# Generate Log and send to Discord
+if(New-ScstLog $log){
+  $null = Submit-TextFile $log $uri
+}

--- a/SCSTCOLLECTDATA.ps1
+++ b/SCSTCOLLECTDATA.ps1
@@ -1,7 +1,5 @@
+# Run a Powershell script that isnt signed ONCE and ONLY DURING THIS SESSION
 Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
-
-#set location to script path
-Set-Location (Split-Path -Parent $MyInvocation.MyCommand.Path)
 
 ###
 #BEGIN SELF ELEVATE TO ADMIN
@@ -20,19 +18,15 @@ if (-Not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdent
 #END SELF ELEVATE TO ADMIN
 ###
 
-
-##
-#The section above allows us to run a Powershell script that isnt signed ONCE and ONLY DURING THIS SESSION
-##
+# Set location to script path
+Set-Location (Split-Path -Parent $MyInvocation.MyCommand.Path)
 
 ##
 #BEGIN VARIABLES
 ##
 
 $PSTitle = "Scavengers Community Support Tool Data Only"
-
 $host.UI.RawUI.WindowTitle = $PSTitle
-
 $scstlog = "SCSTInfo.log"
 
 ##
@@ -44,15 +38,10 @@ $scstlog = "SCSTInfo.log"
 ##
 
 Get-ComputerInfo | Select-Object WindowsProductName, WindowsVersion, OsHardwareAbstractionLayer | Out-File -FilePath "$scstlog" -Encoding utf8 -Force
-
 Get-CimInstance -ClassName CIM_Processor | Select-Object -Property Name, MaxClockSpeed, SocketDesignation, Manufacturer | Out-File -FilePath "$scstlog" -Encoding utf8 -Append
-
 Get-CimInstance -ClassName CIM_VideoController | Format-Table -AutoSize -Property Name, CurrentHorizontalResolution, CurrentVerticalResolution, CurrentRefreshRate, @{Name="AdapterRamGB"; Expression={[int]($_.AdapterRam/1GB)}}, DriverDate, DriverVersion | Out-File -FilePath "$scstlog" -Encoding utf8 -Append
-
 Get-CimInstance -ClassName CIM_PhysicalMemory | Format-Table -AutoSize Manufacturer, PartNumber, Speed, DeviceLocator, @{Name="CapacityGB"; Expression={[int]($_.Capacity/1GB)}} | Out-File -FilePath "$scstlog" -Encoding utf8 -Append
-
 Get-CimInstance -ClassName CIM_DiskDrive | Format-Table -AutoSize DeviceID, Model, @{Name="SizeGB"; Expression={[int]($_.Size/1GB)}} | Out-File -FilePath "$scstlog" -Encoding utf8 -Append
-
 Get-CimInstance -ClassName CIM_LogicalDisk | Format-Table -AutoSize DeviceID, @{Name="SizeGB"; Expression={[int]($_.Size/1GB)}} | Out-File -FilePath "$scstlog" -Encoding utf8 -Append
 
 ##

--- a/Submit-TextFile.ps1
+++ b/Submit-TextFile.ps1
@@ -1,0 +1,14 @@
+function Submit-TextFile($filePath,$Uri){
+    $filename = (Get-ChildItem $filePath).Name
+    $filecontents = Get-Content $filePath -raw
+    $boundary = [guid]::NewGuid().ToString()
+    $contentinfo = "Content-Disposition: form-data; name=`"file`"; filename=`"$filename`"`nContent-Type: text/html; charset=utf-8`n"
+    $body = "--$boundary`n$contentinfo`n$filecontents`n--$boundary--`n"
+    $params = @{
+        Uri         = $Uri
+        Body        = $body
+        Method      = 'Post'
+        ContentType = "multipart/form-data; boundary=$boundary"
+    }
+    Invoke-RestMethod @params
+}


### PR DESCRIPTION
uploader and log generation moved into their own files and now dot included.

removed elevation as that shouldn't be needed for these items. maybe take with a grain of salt, but see here:
https://stackoverflow.com/questions/19279099/what-are-the-permissions-required-for-cimsessions

since we were already using $MyInvocation in the elevation script originally, i used that instead of $psscriptroot to set the location, but this way we know where we are and don't need full paths for anything.

cleanup was commented out previously, so i left that along